### PR TITLE
Provide JRE

### DIFF
--- a/virtual-java.spec
+++ b/virtual-java.spec
@@ -5,7 +5,7 @@ Group: Development/Languages
 Summary: Virtual package which provides java but uses the Sun/Oracle JDK
 License: None
 BuildArch: noarch
-Provides: java
+Provides: java, jre
 Requires: jdk > %VERSION%
 
 %description


### PR DESCRIPTION
Providing 'jre' ensures packages requiring only a java runtime won't pull alternative installations. Can't think of any use-case where providing 'java' would be advisable but providing 'jre' would not.
